### PR TITLE
fix: display CLI help

### DIFF
--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -183,7 +183,7 @@ def main(
         raise typer.Exit()
     if ctx.invoked_subcommand is None:
         # 没有指定子命令时显示帮助信息
-        ctx.get_help()
+        console.print(ctx.get_help())
         raise typer.Exit(0)
 
 


### PR DESCRIPTION
## Summary
- ensure `trans-hub` CLI shows help text when no subcommand is provided

## Testing
- `ruff check trans_hub/cli/__init__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_688f07a2adf4832589dcbe2b68e4e9de