### PR TITLE
feat: add app run command

### DIFF
--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -11,7 +11,6 @@ import structlog
 import typer
 from rich.console import Console
 
-from trans_hub.cli.app.main import app as app_app
 from trans_hub.cli.gc.main import gc as gc_command
 from trans_hub.cli.request.main import request as request_command
 from trans_hub.cli.worker.main import run_worker
@@ -23,9 +22,6 @@ console = Console()
 
 # 创建Typer应用实例
 app = typer.Typer(help="Trans-Hub 命令行工具")
-
-# 添加子命令
-app.add_typer(app_app, name="app", help="应用主入口")
 
 # 全局状态管理
 # 注意：这里简化了状态管理，实际项目中可能需要更复杂的机制
@@ -93,6 +89,12 @@ def _with_coordinator(func: Callable[..., Any]) -> Callable[..., Any]:
             raise typer.Exit(1)
 
     return wrapper
+
+
+from trans_hub.cli.app.main import app as app_app
+
+# 添加子命令
+app.add_typer(app_app, name="app", help="应用主入口")
 
 
 @app.command()

--- a/trans_hub/cli/app/main.py
+++ b/trans_hub/cli/app/main.py
@@ -13,6 +13,7 @@ import typer
 from rich.console import Console
 
 from trans_hub.coordinator import Coordinator
+from trans_hub.cli import _with_coordinator
 
 log = structlog.get_logger("trans_hub.cli.app")
 console = Console()
@@ -59,3 +60,13 @@ def run_app(coordinator: Coordinator, loop: asyncio.AbstractEventLoop) -> NoRetu
             log.info("协调器已关闭")
         # 确保函数永远不会返回
         raise RuntimeError("This function should never return")
+
+
+@app.command("run")
+@_with_coordinator
+def run(
+    coordinator: Coordinator,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """启动 Trans-Hub 主应用循环。"""
+    run_app(coordinator, loop)


### PR DESCRIPTION
## Summary
- add `run` command to app CLI that bootstraps coordinator and event loop
- register app subcommand after coordinator helpers to enable `trans-hub app run`

## Testing
- `python3.12 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_688f0d3a2770832590e1b159c2cf6ef3