### PR TITLE
feat(cli): require langs for worker command

### DIFF
--- a/docs_old/zh/guides/05_cli_commands.md
+++ b/docs_old/zh/guides/05_cli_commands.md
@@ -27,20 +27,19 @@ python -m trans_hub.cli_main app [子命令]
 启动 Trans-Hub Worker 进程，处理待翻译任务。
 
 **参数**:
-- `--lang`, `-l`: 要处理的语言列表（可选）
+- `--lang`, `-l`: 要处理的语言列表（必需，至少指定一个）
 - `--batch-size`, `-b`: 每批处理的任务数量，默认值为 10
 - `--poll-interval`, `-p`: 轮询间隔（秒），默认值为 5.0
 
+> 未指定 `--lang` 时命令将失败。
+
 **示例**:
 ```bash
-# 启动 Worker 进程，处理所有语言的任务
-python -m trans_hub.cli_main worker
-
 # 启动 Worker 进程，只处理英语和中文任务
 python -m trans_hub.cli_main worker --lang en zh
 
 # 自定义批处理大小为 20，轮询间隔为 10 秒
-python -m trans_hub.cli_main worker --batch-size 20 --poll-interval 10
+python -m trans_hub.cli_main worker --lang en --batch-size 20 --poll-interval 10
 ```
 
 ### request

--- a/tests/unit/cli/test_worker_no_lang.py
+++ b/tests/unit/cli/test_worker_no_lang.py
@@ -1,0 +1,22 @@
+import pytest
+from typer.testing import CliRunner
+from unittest.mock import MagicMock, patch
+
+from trans_hub.cli import app
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_worker_requires_lang(runner: CliRunner) -> None:
+    with patch("trans_hub.cli._initialize_coordinator") as mock_init, patch(
+        "trans_hub.cli.run_worker"
+    ) as mock_run_worker:
+        mock_init.return_value = (MagicMock(), MagicMock())
+        result = runner.invoke(app, ["worker"])
+    assert result.exit_code != 0
+    assert "--lang" in result.output
+    mock_run_worker.assert_not_called()
+

--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -100,7 +100,9 @@ def _with_coordinator(func: Callable[..., Any]) -> Callable[..., Any]:
 def worker(
     coordinator: Coordinator,
     loop: asyncio.AbstractEventLoop,
-    langs: list[str] = typer.Option([], "--lang", "-l", help="要处理的语言列表"),
+    langs: list[str] = typer.Option(
+        [], "--lang", "-l", help="要处理的语言列表（至少指定一个）"
+    ),
     batch_size: int = typer.Option(10, "--batch-size", "-b", help="每批处理的任务数量"),
     poll_interval: int = typer.Option(
         5, "--poll-interval", "-p", help="轮询间隔（秒）"
@@ -109,6 +111,11 @@ def worker(
     """
     启动Trans-Hub Worker进程，处理待翻译任务。
     """
+    if not langs:
+        log.error("No target languages specified for worker")
+        console.print("[red]❌ 必须使用 --lang 指定至少一个语言[/red]")
+        raise typer.Exit(1)
+
     # 创建关闭事件
     shutdown_event = asyncio.Event()
     run_worker(coordinator, loop, shutdown_event, langs, batch_size, poll_interval)


### PR DESCRIPTION
## Summary
- validate that `worker` CLI subcommand receives at least one `--lang`
- document the requirement for specifying languages when running the worker
- add CLI test ensuring worker fails when no languages are provided

## Testing
- `PYENV_VERSION=3.11.12 pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*
- `PYENV_VERSION=3.11.12 pip install -e .` *(fails: Could not find a version that satisfies the requirement poetry-core>=1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_688f0d438e188325a911a12004077fee