### PR TITLE
refactor(cli): remove skip_init from coordinator initialization

### DIFF
--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -43,12 +43,8 @@ class State:
         self.loop: Optional[asyncio.AbstractEventLoop] = None
 
 
-def _initialize_coordinator(
-    skip_init: bool = False,
-) -> tuple[Coordinator, asyncio.AbstractEventLoop]:
-    """
-    初始化协调器和事件循环。
-    """
+def _initialize_coordinator() -> tuple[Coordinator, asyncio.AbstractEventLoop]:
+    """初始化协调器和事件循环并执行初始化。"""
     global _coordinator, _loop
 
     if _coordinator is not None and _loop is not None:
@@ -64,9 +60,7 @@ def _initialize_coordinator(
 
     _persistence_handler = SQLitePersistenceHandler(config.database_url)
     _coordinator = Coordinator(config, _persistence_handler)
-
-    if not skip_init:
-        _loop.run_until_complete(_coordinator.initialize())
+    _loop.run_until_complete(_coordinator.initialize())
 
     return _coordinator, _loop
 


### PR DESCRIPTION
## Summary
- remove skip_init flag from `_initialize_coordinator`
- always run coordinator initialization

## Testing
- `PYENV_VERSION=3.11.12 ruff check trans_hub/cli/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_688f2ed5b48c832592b5de31aa7a278d