### PR TITLE
Use config-based default for CLI gc retention

### DIFF
--- a/tests/unit/cli/test_gc.py
+++ b/tests/unit/cli/test_gc.py
@@ -10,9 +10,9 @@ from typing import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import questionary
 
 from trans_hub.cli.gc.main import gc
+from trans_hub.config import TransHubConfig
 from trans_hub.coordinator import Coordinator
 
 
@@ -48,7 +48,7 @@ def test_gc_dry_run(
 ) -> None:
     """测试 gc 命令的干运行模式。"""
     # 准备测试数据
-    retention_days = 90
+    retention_days = TransHubConfig().gc_retention_days
     dry_run = True
 
     # 模拟垃圾回收报告
@@ -78,7 +78,7 @@ def test_gc_real_run_confirmed(
 ) -> None:
     """测试 gc 命令的实际运行模式（用户确认）。"""
     # 准备测试数据
-    retention_days = 90
+    retention_days = TransHubConfig().gc_retention_days
     dry_run = False
 
     # 模拟垃圾回收报告
@@ -117,7 +117,7 @@ def test_gc_real_run_cancelled(
 ) -> None:
     """测试 gc 命令的实际运行模式（用户取消）。"""
     # 准备测试数据
-    retention_days = 90
+    retention_days = TransHubConfig().gc_retention_days
     dry_run = False
 
     # 模拟垃圾回收报告
@@ -155,7 +155,7 @@ def test_gc_no_data_to_clean(
 ) -> None:
     """测试 gc 命令在没有数据可清理时的行为。"""
     # 准备测试数据
-    retention_days = 90
+    retention_days = TransHubConfig().gc_retention_days
     dry_run = False
 
     # 模拟空垃圾回收报告

--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -32,6 +32,9 @@ app.add_typer(app_app, name="app", help="应用主入口")
 _coordinator: Optional[Coordinator] = None
 _loop: Optional[asyncio.AbstractEventLoop] = None
 
+# 配置默认值
+DEFAULT_GC_RETENTION_DAYS = TransHubConfig().gc_retention_days
+
 
 class State:
     """
@@ -144,7 +147,15 @@ def request(
 def gc(
     coordinator: Coordinator,
     loop: asyncio.AbstractEventLoop,
-    retention_days: int = typer.Option(90, "--retention-days", "-r", help="保留天数"),
+    retention_days: int = typer.Option(
+        DEFAULT_GC_RETENTION_DAYS,
+        "--retention-days",
+        "-r",
+        help=(
+            f"保留天数（默认: {DEFAULT_GC_RETENTION_DAYS} 天，来自配置 "
+            "gc_retention_days）"
+        ),
+    ),
     dry_run: bool = typer.Option(False, "--dry-run", "-d", help="仅预览，不执行删除"),
 ) -> None:
     """


### PR DESCRIPTION
## Summary
- pull gc retention default from `TransHubConfig.gc_retention_days`
- note the config-derived default in the CLI help text
- derive test retention defaults from configuration

## Testing
- `PYENV_VERSION=3.12.10 ruff check trans_hub/cli/__init__.py tests/unit/cli/test_gc.py` (fails: E501 line too long in tests)
- `PYENV_VERSION=3.12.10 pytest tests/unit/cli/test_gc.py` (fails: ModuleNotFoundError: No module named 'questionary'; `pip install questionary` failed with proxy 403)


------
https://chatgpt.com/codex/tasks/task_e_688f2ed42b808325a52cca1409e0fd56