### PR TITLE
Ensure CLI wrapper cleans up coordinator and loop

### DIFF
--- a/tests/unit/cli/test_gc.py
+++ b/tests/unit/cli/test_gc.py
@@ -171,3 +171,26 @@ def test_gc_no_data_to_clean(
     )
     # 验证没有显示确认对话框
     assert "数据库很干净，无需进行垃圾回收" in str(mock_console_print.call_args_list)
+
+
+@patch("trans_hub.cli.gc_command")
+@patch("trans_hub.cli._initialize_coordinator")
+def test_cli_gc_closes_loop(
+    mock_init: MagicMock, mock_gc_command: MagicMock
+) -> None:
+    """确保 CLI gc 命令退出时会关闭事件循环。"""
+    mock_coordinator = MagicMock(spec=Coordinator)
+    mock_coordinator.close = AsyncMock()
+    mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    mock_loop.run_until_complete = MagicMock()
+    mock_loop.close = MagicMock()
+    mock_init.return_value = (mock_coordinator, mock_loop)
+
+    from trans_hub.cli import gc as cli_gc
+
+    cli_gc(retention_days=1, dry_run=True)
+
+    mock_gc_command.assert_called_once_with(mock_coordinator, mock_loop, 1, True)
+    mock_loop.run_until_complete.assert_called_once()
+    mock_coordinator.close.assert_called_once()
+    mock_loop.close.assert_called_once()

--- a/tests/unit/cli/test_worker.py
+++ b/tests/unit/cli/test_worker.py
@@ -106,12 +106,8 @@ async def test_run_worker_initialization(
     # 验证初始化
     # 检查信号处理器是否被调用
     assert mock_event_loop.add_signal_handler.call_count >= 2, f"信号处理器调用次数不足: {mock_event_loop.add_signal_handler.call_count}"
-    
-    # 检查协调器是否被关闭
-    if mock_coordinator.close.call_count == 0:
-        print("警告: coordinator.close 未被调用")
-    else:
-        assert mock_coordinator.close.call_count == 1, f"coordinator.close 调用次数不正确: {mock_coordinator.close.call_count}"
+    # run_worker 不再负责关闭协调器
+    assert mock_coordinator.close.call_count == 0
 
 
 @pytest.mark.asyncio
@@ -438,3 +434,26 @@ async def test_process_pending_translations_called(
     # 验证 process_pending_translations 被调用
     print(f"process_pending_translations 最终调用次数: {mock_coordinator.process_pending_translations.call_count}")
     assert mock_coordinator.process_pending_translations.call_count > 0, "process_pending_translations 未被调用"
+
+
+@patch("trans_hub.cli.run_worker")
+@patch("trans_hub.cli._initialize_coordinator")
+def test_cli_worker_closes_loop(
+    mock_init: MagicMock, mock_run_worker: MagicMock
+) -> None:
+    """确保 CLI worker 命令退出时会关闭事件循环。"""
+    mock_coordinator = MagicMock(spec=Coordinator)
+    mock_coordinator.close = AsyncMock()
+    mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    mock_loop.run_until_complete = MagicMock()
+    mock_loop.close = MagicMock()
+    mock_init.return_value = (mock_coordinator, mock_loop)
+
+    from trans_hub.cli import worker as cli_worker
+
+    cli_worker()
+
+    mock_run_worker.assert_called_once()
+    mock_loop.run_until_complete.assert_called_once()
+    mock_coordinator.close.assert_called_once()
+    mock_loop.close.assert_called_once()

--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -91,6 +91,16 @@ def _with_coordinator(func: Callable[..., Any]) -> Callable[..., Any]:
             log.error("命令执行失败", error=str(e), exc_info=True)
             console.print(f"[red]❌ 命令执行失败: {e}[/red]")
             raise typer.Exit(1)
+        finally:
+            global _coordinator, _loop
+            try:
+                if coordinator and loop:
+                    loop.run_until_complete(coordinator.close())
+            finally:
+                if loop:
+                    loop.close()
+            _coordinator = None
+            _loop = None
 
     return wrapper
 

--- a/trans_hub/cli/request/main.py
+++ b/trans_hub/cli/request/main.py
@@ -59,9 +59,3 @@ def request(
     except Exception as e:
         log.error("请求处理失败", error=str(e), exc_info=True)
         raise SystemExit(1)
-    finally:
-        # 确保协调器已关闭
-        if coordinator:
-            log.info("请求处理完成，正在关闭协调器...")
-            loop.run_until_complete(coordinator.close())
-            log.info("协调器已关闭")

--- a/trans_hub/cli/worker/main.py
+++ b/trans_hub/cli/worker/main.py
@@ -148,10 +148,3 @@ def run_worker(
                 except Exception as e:
                     log.error(f"任务 {task} 取消时发生异常: {e}", exc_info=True)
 
-    # 执行协调器的优雅关闭
-    log.info("Worker 任务已完成，正在关闭协调器...")
-    try:
-        loop.run_until_complete(coordinator.close())
-        log.info("协调器已成功关闭")
-    except Exception as e:
-        log.error(f"关闭协调器时发生异常: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- ensure CLI commands always close the coordinator and event loop via a finalizer
- drop per-command shutdown code now centralized in the wrapper
- add tests validating that the loop's `close` method is called when commands finish

## Testing
- `python -m pytest tests/unit/cli` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pip install typer pydantic structlog rich questionary` *(fails: Could not find a version that satisfies the requirement typer)*

------
https://chatgpt.com/codex/tasks/task_e_688f2ed074bc83258e596994c69d18c5