### PR TITLE
Configure CLI logging early

### DIFF
--- a/tests/unit/cli/test_logging.py
+++ b/tests/unit/cli/test_logging.py
@@ -1,0 +1,35 @@
+import json
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from trans_hub.cli import app
+
+
+def test_logging_configuration_applied_json() -> None:
+    runner = CliRunner()
+
+    with (
+        patch("trans_hub.cli.Coordinator") as MockCoordinator,
+        patch("trans_hub.persistence.sqlite.SQLitePersistenceHandler"),
+        patch("trans_hub.cli.gc_command") as mock_gc_command,
+    ):
+        MockCoordinator.return_value.initialize = AsyncMock()
+        mock_gc_command.return_value = None
+        result = runner.invoke(
+            app, ["gc", "--dry-run"], env={"TH_LOGGING__FORMAT": "json"}
+        )
+
+    assert result.exit_code == 0
+    found = False
+    for line in result.output.splitlines():
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if data.get("event") == "日志系统已配置完成。":
+            assert data.get("log_format") == "json"
+            assert data.get("app_log_level") == "INFO"
+            found = True
+            break
+    assert found, "logging setup message not found"

--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -17,6 +17,7 @@ from trans_hub.cli.request.main import request as request_command
 from trans_hub.cli.worker.main import run_worker
 from trans_hub.config import TransHubConfig
 from trans_hub.coordinator import Coordinator
+from trans_hub.logging_config import setup_logging
 
 log = structlog.get_logger("trans_hub.cli")
 console = Console()
@@ -60,6 +61,10 @@ def _initialize_coordinator(
 
     # 初始化协调器
     config = TransHubConfig()
+    setup_logging(
+        log_level=config.logging.level,
+        log_format=config.logging.format,
+    )
     from trans_hub.persistence.sqlite import SQLitePersistenceHandler
 
     _persistence_handler = SQLitePersistenceHandler(config.database_url)


### PR DESCRIPTION
## Summary
- configure `trans_hub.cli` to call `setup_logging` using `TransHubConfig.logging`
- add unit test ensuring CLI outputs structured JSON logs when requested

## Testing
- `ruff trans_hub/cli/__init__.py tests/unit/cli/test_logging.py` *(failed: pyenv: version `3.12.11` is not installed; ruff: command not found)*
- `pip install ruff --break-system-packages` *(failed: Could not find a version that satisfies the requirement ruff)*
- `pytest` *(failed: pyenv: version `3.12.11` is not installed; pytest: command not found)*
- `pip install pytest --break-system-packages` *(failed: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_688f2ce4780483259624133f6dec969a