### PR TITLE
refactor(cli): remove unused State class

### DIFF
--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -32,17 +32,6 @@ app.add_typer(app_app, name="app", help="应用主入口")
 _coordinator: Optional[Coordinator] = None
 _loop: Optional[asyncio.AbstractEventLoop] = None
 
-
-class State:
-    """
-    全局状态类，用于存储CLI运行时的状态信息。
-    """
-
-    def __init__(self) -> None:
-        self.coordinator: Optional[Coordinator] = None
-        self.loop: Optional[asyncio.AbstractEventLoop] = None
-
-
 def _initialize_coordinator(
     skip_init: bool = False,
 ) -> tuple[Coordinator, asyncio.AbstractEventLoop]:


### PR DESCRIPTION
## Summary
- remove unused State class from CLI module

## Testing
- `PYENV_VERSION=3.12.10 ruff check trans_hub/cli/__init__.py`
- `PYENV_VERSION=3.12.10 pytest` *(fails: Unknown config option warning; 13 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688f2aff11d88325a9fd8335a7ba62c5