### PR TITLE
Reset coordinator globals after closure

### DIFF
--- a/tests/unit/cli/test_coordinator_reinit.py
+++ b/tests/unit/cli/test_coordinator_reinit.py
@@ -1,0 +1,61 @@
+import pytest
+from typer.testing import CliRunner
+
+import trans_hub.cli as cli
+
+
+class DummyCoordinator:
+    def __init__(self, config, handler):
+        self.initialized = False
+        created.append(self)
+
+    async def initialize(self):
+        self.initialized = True
+
+    async def request(self, *args, **kwargs):
+        return None
+
+    async def close(self):
+        self.initialized = False
+
+
+class DummyPersistenceHandler:
+    def __init__(self, url):
+        pass
+
+
+class DummyConfig:
+    database_url = "sqlite://"
+
+    def __init__(self):
+        pass
+
+
+created = []
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_consecutive_commands_reinitialize_coordinator(monkeypatch, runner):
+    monkeypatch.setattr(cli, "Coordinator", DummyCoordinator)
+    monkeypatch.setattr(cli, "TransHubConfig", DummyConfig)
+    monkeypatch.setattr(
+        "trans_hub.persistence.sqlite.SQLitePersistenceHandler",
+        DummyPersistenceHandler,
+    )
+
+    result1 = runner.invoke(cli.app, ["request", "hello", "--target", "zh"])
+    assert result1.exit_code == 0
+    assert cli._coordinator is None
+    assert cli._loop is None
+
+    result2 = runner.invoke(cli.app, ["request", "hello", "--target", "zh"])
+    assert result2.exit_code == 0
+    assert cli._coordinator is None
+    assert cli._loop is None
+
+    assert len(created) == 2
+    assert created[0] is not created[1]

--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -51,7 +51,11 @@ def _initialize_coordinator(
     """
     global _coordinator, _loop
 
-    if _coordinator is not None and _loop is not None:
+    if (
+        _coordinator is not None
+        and _loop is not None
+        and _coordinator.initialized
+    ):
         return _coordinator, _loop
 
     # 创建新的事件循环

--- a/trans_hub/cli/app/main.py
+++ b/trans_hub/cli/app/main.py
@@ -57,5 +57,14 @@ def run_app(coordinator: Coordinator, loop: asyncio.AbstractEventLoop) -> NoRetu
             log.info("应用退出，正在关闭协调器...")
             loop.run_until_complete(coordinator.close())
             log.info("协调器已关闭")
+        loop.close()
+        # 重置全局状态，允许后续命令重新初始化
+        try:
+            import trans_hub.cli as cli_main
+
+            cli_main._coordinator = None
+            cli_main._loop = None
+        except Exception:
+            pass
         # 确保函数永远不会返回
         raise RuntimeError("This function should never return")

--- a/trans_hub/cli/request/main.py
+++ b/trans_hub/cli/request/main.py
@@ -65,3 +65,12 @@ def request(
             log.info("请求处理完成，正在关闭协调器...")
             loop.run_until_complete(coordinator.close())
             log.info("协调器已关闭")
+            loop.close()
+            # 重置全局状态以便后续命令可重新初始化
+            try:
+                import trans_hub.cli as cli_main
+
+                cli_main._coordinator = None
+                cli_main._loop = None
+            except Exception:
+                pass

--- a/trans_hub/cli/worker/main.py
+++ b/trans_hub/cli/worker/main.py
@@ -155,3 +155,12 @@ def run_worker(
         log.info("协调器已成功关闭")
     except Exception as e:
         log.error(f"关闭协调器时发生异常: {e}", exc_info=True)
+    finally:
+        loop.close()
+        try:
+            import trans_hub.cli as cli_main
+
+            cli_main._coordinator = None
+            cli_main._loop = None
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- ensure coordinator initialized before reuse
- reset coordinator and event loop globals when CLI commands close them
- add regression test for sequential CLI invocations

## Testing
- `PYENV_VERSION=3.12.10 python -m pytest tests/unit/cli/test_coordinator_reinit.py::test_consecutive_commands_reinitialize_coordinator -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `PYENV_VERSION=3.12.10 pip install typer rich structlog questionary -q` *(fails: Could not find a version that satisfies the requirement typer)*

------
https://chatgpt.com/codex/tasks/task_e_688f2b4d06e4832584cb03cb4c166033