### PR TITLE
Ensure GC closes coordinator

### DIFF
--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -71,6 +71,13 @@ def _initialize_coordinator(
     return _coordinator, _loop
 
 
+def reset_state() -> None:
+    """重置全局协调器和事件循环状态。"""
+    global _coordinator, _loop
+    _coordinator = None
+    _loop = None
+
+
 def _with_coordinator(func: Callable[..., Any]) -> Callable[..., Any]:
     """
     装饰器，用于为CLI命令提供协调器和事件循环。

--- a/trans_hub/cli/gc/main.py
+++ b/trans_hub/cli/gc/main.py
@@ -25,47 +25,53 @@ def gc(
     """
     执行数据库垃圾回收，清理过期的、无关联的旧数据。
     """
-    mode = "Dry Run" if dry_run else "执行"
-    console.print(
-        f"[yellow]即将为超过 {retention_days} 天的非活跃任务执行垃圾回收 "
-        f"({mode})...[/yellow]"
-    )
-
-    report = loop.run_until_complete(
-        coordinator.run_garbage_collection(retention_days, True)
-    )
-
-    table = Table(title="垃圾回收预报告")
-    table.add_column("项目", style="cyan")
-    table.add_column("将被删除数量", style="magenta", justify="right")
-    table.add_row("关联任务 (Jobs)", str(report.get("deleted_jobs", 0)))
-    table.add_row("原文内容 (Content)", str(report.get("deleted_content", 0)))
-    table.add_row("上下文 (Contexts)", str(report.get("deleted_contexts", 0)))
-
-    console.print(table)
-
-    if all(v == 0 for v in report.values()):
-        console.print("[green]数据库很干净，无需进行垃圾回收。[/green]")
-        return
-
-    if not dry_run:
-        # 使用 run_until_complete 来运行异步的 questionary.confirm
-        proceed = loop.run_until_complete(
-            questionary.confirm(
-                "这是一个破坏性操作，是否继续执行删除？",
-                default=False,
-                auto_enter=False,
-            ).ask_async()
+    try:
+        mode = "Dry Run" if dry_run else "执行"
+        console.print(
+            f"[yellow]即将为超过 {retention_days} 天的非活跃任务执行垃圾回收 "
+            f"({mode})...[/yellow]"
         )
 
-        if not proceed:
-            console.print("[red]操作已取消。[/red]")
+        report = loop.run_until_complete(
+            coordinator.run_garbage_collection(retention_days, True)
+        )
+
+        table = Table(title="垃圾回收预报告")
+        table.add_column("项目", style="cyan")
+        table.add_column("将被删除数量", style="magenta", justify="right")
+        table.add_row("关联任务 (Jobs)", str(report.get("deleted_jobs", 0)))
+        table.add_row("原文内容 (Content)", str(report.get("deleted_content", 0)))
+        table.add_row("上下文 (Contexts)", str(report.get("deleted_contexts", 0)))
+
+        console.print(table)
+
+        if all(v == 0 for v in report.values()):
+            console.print("[green]数据库很干净，无需进行垃圾回收。[/green]")
             return
 
-        console.print("[yellow]正在执行删除操作...[/yellow]")
-        loop.run_until_complete(
-            coordinator.run_garbage_collection(retention_days, False)
-        )
-        console.print("[green]✅ 垃圾回收执行完毕！[/green]")
-        # 注意：这里可能需要调整，因为 assert 在生产环境中通常不会执行
-        # assert final_report == report, "最终报告与预报告不符，可能存在并发问题"
+        if not dry_run:
+            # 使用 run_until_complete 来运行异步的 questionary.confirm
+            proceed = loop.run_until_complete(
+                questionary.confirm(
+                    "这是一个破坏性操作，是否继续执行删除？",
+                    default=False,
+                    auto_enter=False,
+                ).ask_async()
+            )
+
+            if not proceed:
+                console.print("[red]操作已取消。[/red]")
+                return
+
+            console.print("[yellow]正在执行删除操作...[/yellow]")
+            loop.run_until_complete(
+                coordinator.run_garbage_collection(retention_days, False)
+            )
+            console.print("[green]✅ 垃圾回收执行完毕！[/green]")
+            # 注意：这里可能需要调整，因为 assert 在生产环境中通常不会执行
+            # assert final_report == report, "最终报告与预报告不符，可能存在并发问题"
+    finally:
+        loop.run_until_complete(coordinator.close())
+        from trans_hub.cli import reset_state
+
+        reset_state()


### PR DESCRIPTION
## Summary
- guarantee garbage collection CLI closes the coordinator and resets global state
- add helper to reset CLI coordinator/loop
- extend GC CLI tests to assert coordinator closure

## Testing
- `python3.12 -m py_compile trans_hub/cli/gc/main.py trans_hub/cli/__init__.py tests/unit/cli/test_gc.py`
- `python3.12 -m pytest tests/unit/cli/test_gc.py -q` *(fails: No module named pytest)*
- `.venv/bin/pip install -e .[cli,dev]` *(fails: Could not find a version that satisfies the requirement poetry-core>=1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_688f2b5da6b083258eab537177cf7ee1