### PR TITLE
Fallback to signal.signal when event loop lacks add_signal_handler

### DIFF
--- a/trans_hub/cli/worker/main.py
+++ b/trans_hub/cli/worker/main.py
@@ -43,8 +43,13 @@ def run_worker(
             log.warning("关闭事件未初始化，无法触发优雅停机")
 
     # 注册信号处理器
-    loop.add_signal_handler(signal.SIGTERM, signal_handler, signal.SIGTERM, None)
-    loop.add_signal_handler(signal.SIGINT, signal_handler, signal.SIGINT, None)
+    try:
+        loop.add_signal_handler(signal.SIGTERM, signal_handler, signal.SIGTERM, None)
+        loop.add_signal_handler(signal.SIGINT, signal_handler, signal.SIGINT, None)
+    except NotImplementedError:
+        # 在不支持 add_signal_handler 的平台上回退到 signal.signal
+        signal.signal(signal.SIGTERM, signal_handler)
+        signal.signal(signal.SIGINT, signal_handler)
 
     async def process_language(target_lang: str) -> None:
         """处理单一语言的循环。"""


### PR DESCRIPTION
## Summary
- handle platforms without `loop.add_signal_handler` by falling back to `signal.signal`
- add unit test verifying the `signal.signal` fallback path

## Testing
- `ruff trans_hub/cli/worker/main.py tests/unit/cli/test_worker.py` *(fails: pyenv: ruff: command not found)*
- `python3 -m pytest tests/unit/cli/test_worker.py` *(fails: No module named pytest)*


------
https://chatgpt.com/codex/tasks/task_e_688f2b6765508325937e464e1258dd89