### PR TITLE
Refactor worker cleanup to use current asyncio APIs

### DIFF
--- a/tests/unit/cli/test_worker.py
+++ b/tests/unit/cli/test_worker.py
@@ -196,12 +196,6 @@ async def test_run_worker_processing(
     # 验证任务处理
     # 验证方法被调用
     assert mock_coordinator.process_pending_translations.call_count > 0, "process_pending_translations 未被调用"
-    # 移除严格的调用次数断言，因为run_worker可能会多次调用该方法
-    # mock_coordinator.process_pending_translations.assert_called_once()
-    # 如果需要验证参数，可以使用
-    # args, kwargs = mock_coordinator.process_pending_translations.call_args
-    # assert args[0] == "en"
-    # assert args[1] == batch_size
 
 
 @pytest.mark.asyncio
@@ -438,3 +432,34 @@ async def test_process_pending_translations_called(
     # 验证 process_pending_translations 被调用
     print(f"process_pending_translations 最终调用次数: {mock_coordinator.process_pending_translations.call_count}")
     assert mock_coordinator.process_pending_translations.call_count > 0, "process_pending_translations 未被调用"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cancels_pending_tasks() -> None:
+    """确保清理逻辑能够取消未完成的任务。"""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    coordinator = MagicMock(spec=Coordinator)
+    coordinator.process_pending_translations = AsyncMock()
+    coordinator.close = AsyncMock()
+
+    shutdown_event = asyncio.Event()
+
+    async def long_running() -> None:
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            pass
+
+    pending_task = loop.create_task(long_running())
+
+    # 触发立即关闭以运行清理逻辑
+    loop.call_soon(shutdown_event.set)
+
+    run_worker(coordinator, loop, shutdown_event, [])
+
+    assert pending_task.cancelled(), "未完成的任务应被取消"
+
+    loop.run_until_complete(asyncio.sleep(0))
+    loop.close()

--- a/trans_hub/cli/worker/main.py
+++ b/trans_hub/cli/worker/main.py
@@ -134,19 +134,27 @@ def run_worker(
         log.error(f"worker任务集合执行异常: {e}", exc_info=True)
 
     # 确保所有任务都已完成或被取消
-    pending_tasks = asyncio.all_tasks(loop=loop)
-    current_task = asyncio.current_task(loop=loop)
-    if pending_tasks:
-        log.info(f"仍有 {len(pending_tasks)} 个未完成的任务，正在取消...")
-        for task in pending_tasks:
-            if task != current_task:
+    async def cancel_pending_tasks() -> None:
+        pending_tasks = asyncio.all_tasks()
+        current_task = asyncio.current_task()
+        tasks_to_cancel = [t for t in pending_tasks if t is not current_task]
+        if tasks_to_cancel:
+            log.info(f"仍有 {len(tasks_to_cancel)} 个未完成的任务，正在取消...")
+            for task in tasks_to_cancel:
                 task.cancel()
+            for task in tasks_to_cancel:
                 try:
-                    loop.run_until_complete(task)
+                    await task
+                    log.info(f"任务 {task} 已完成")
                 except asyncio.CancelledError:
                     log.info(f"任务 {task} 已取消")
                 except Exception as e:
-                    log.error(f"任务 {task} 取消时发生异常: {e}", exc_info=True)
+                    log.error(
+                        f"任务 {task} 取消时发生异常: {e}",
+                        exc_info=True,
+                    )
+
+    loop.run_until_complete(cancel_pending_tasks())
 
     # 执行协调器的优雅关闭
     log.info("Worker 任务已完成，正在关闭协调器...")


### PR DESCRIPTION
## Summary
- modernize worker shutdown by cancelling pending tasks via `asyncio.all_tasks()` and `asyncio.current_task()`
- add regression test ensuring pending worker tasks are cancelled during cleanup

## Testing
- `python3 -m py_compile trans_hub/cli/worker/main.py`
- `python3 -m py_compile tests/unit/cli/test_worker.py`
- `python3 -m pytest tests/unit/cli/test_worker.py::test_cleanup_cancels_pending_tasks -q` *(fails: No module named 'pytest')*
- `pip install pytest pytest-asyncio structlog --break-system-packages -q` *(fails: Could not find a version because of proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_688f2cca27a08325bfde18cd2bf13b69