### PR TITLE
feat: validate CLI language codes

### DIFF
--- a/tests/unit/cli/test_lang_code_validation.py
+++ b/tests/unit/cli/test_lang_code_validation.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from trans_hub.cli import app
+
+runner = CliRunner()
+
+
+def test_worker_invalid_lang_code() -> None:
+    """Worker command should fail on invalid language codes."""
+    with patch("trans_hub.cli._initialize_coordinator") as mock_init:
+        mock_init.return_value = (MagicMock(), MagicMock())
+        result = runner.invoke(app, ["worker", "--lang", "invalid-lang"])
+    assert result.exit_code != 0
+    assert "格式无效" in result.output
+
+
+def test_request_invalid_target_lang() -> None:
+    """Request command should fail on invalid language codes."""
+    with patch("trans_hub.cli._initialize_coordinator") as mock_init:
+        mock_init.return_value = (MagicMock(), MagicMock())
+        result = runner.invoke(app, ["request", "hello", "--target", "bad-code"])
+    assert result.exit_code != 0
+    assert "格式无效" in result.output

--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -17,6 +17,7 @@ from trans_hub.cli.request.main import request as request_command
 from trans_hub.cli.worker.main import run_worker
 from trans_hub.config import TransHubConfig
 from trans_hub.coordinator import Coordinator
+from trans_hub.utils import validate_lang_codes
 
 log = structlog.get_logger("trans_hub.cli")
 console = Console()
@@ -109,6 +110,9 @@ def worker(
     """
     启动Trans-Hub Worker进程，处理待翻译任务。
     """
+    # 校验语言代码
+    validate_lang_codes(langs)
+
     # 创建关闭事件
     shutdown_event = asyncio.Event()
     run_worker(coordinator, loop, shutdown_event, langs, batch_size, poll_interval)
@@ -134,6 +138,9 @@ def request(
     """
     提交一个新的翻译请求到队列中。
     """
+    # 校验目标语言代码
+    validate_lang_codes(target_lang)
+
     request_command(
         coordinator, loop, text, target_lang, source_lang, business_id, force
     )


### PR DESCRIPTION
## Summary
- validate CLI `worker` and `request` language options via `validate_lang_codes`
- add CLI tests for invalid language codes

## Testing
- `PYENV_VERSION=3.12.10 ruff check trans_hub/cli/__init__.py tests/unit/cli/test_lang_code_validation.py`
- `PYENV_VERSION=3.12.10 pytest tests/unit/cli/test_lang_code_validation.py -q` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_688f2cda0b688325a58f5ef4a43d1bf4