### PR TITLE
feat(cli): use config batch size default

### DIFF
--- a/tests/unit/cli/test_worker.py
+++ b/tests/unit/cli/test_worker.py
@@ -15,6 +15,7 @@ import pytest
 from trans_hub.cli.worker.main import run_worker
 from trans_hub.coordinator import Coordinator
 from trans_hub.types import TranslationResult, TranslationStatus
+from trans_hub.config import TransHubConfig
 import tracemalloc
 
 tracemalloc.start()
@@ -59,7 +60,7 @@ async def test_run_worker_initialization(
     """测试 run_worker 函数的初始化。"""
     # 准备测试数据
     langs = ["en", "zh-CN"]
-    batch_size = 10
+    batch_size = TransHubConfig().batch_size
     polling_interval = 5
 
     # 模拟 process_pending_translations 返回空的异步生成器

--- a/trans_hub/cli/__init__.py
+++ b/trans_hub/cli/__init__.py
@@ -20,6 +20,7 @@ from trans_hub.coordinator import Coordinator
 
 log = structlog.get_logger("trans_hub.cli")
 console = Console()
+DEFAULT_BATCH_SIZE = TransHubConfig().batch_size
 
 # 创建Typer应用实例
 app = typer.Typer(help="Trans-Hub 命令行工具")
@@ -101,7 +102,12 @@ def worker(
     coordinator: Coordinator,
     loop: asyncio.AbstractEventLoop,
     langs: list[str] = typer.Option([], "--lang", "-l", help="要处理的语言列表"),
-    batch_size: int = typer.Option(10, "--batch-size", "-b", help="每批处理的任务数量"),
+    batch_size: int = typer.Option(
+        DEFAULT_BATCH_SIZE,
+        "--batch-size",
+        "-b",
+        help=f"每批处理的任务数量（默认读取配置 batch_size={DEFAULT_BATCH_SIZE}）",
+    ),
     poll_interval: int = typer.Option(
         5, "--poll-interval", "-p", help="轮询间隔（秒）"
     ),


### PR DESCRIPTION
## Summary
- default worker batch size from config and document the source
- align CLI unit test with config-based batch size

## Testing
- `PYENV_VERSION=3.12.10 ruff check trans_hub/cli/__init__.py`
- `PYENV_VERSION=3.12.10 pytest tests/unit/cli` *(fails: ModuleNotFoundError: No module named 'typer')*
- `PYENV_VERSION=3.12.10 pip install -e .` *(fails: Could not find a version that satisfies the requirement poetry-core)*

------
https://chatgpt.com/codex/tasks/task_e_688f2cd2a6cc832585cfb5d897e37d95